### PR TITLE
Fixed bug 'SQLSTATE[42000]: Syntax error or access violation: 1071 Sp…

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Schema;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -13,7 +14,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Schema::defaultStringLength(191);
     }
 
     /**


### PR DESCRIPTION
Error message "SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 767 bytes" occurred after running php artisan migrate. This is due to the MySql version being older than 5.7. AppServiceProvider.php' boot method was updated to address this. 